### PR TITLE
Move listing of objects to separate thread using a FIFO queue.

### DIFF
--- a/src/s3fetch/__init__.py
+++ b/src/s3fetch/__init__.py
@@ -24,9 +24,14 @@ __version__ = pkg_resources.get_distribution("s3fetch").version
     type=str,
     help="Download directory. Defaults to current directory.",
 )
-@click.option("--regex", type=str, help="Filter list of available objects by regex.")
 @click.option(
-    "--threads", type=int, help="Number of threads to use. Defaults to core count."
+    "-r", "--regex", type=str, help="Filter list of available objects by regex."
+)
+@click.option(
+    "-t",
+    "--threads",
+    type=int,
+    help="Number of threads to use. Defaults to core count.",
 )
 @click.option(
     "--dry-run", "--list-only", is_flag=True, help="List objects only, do not download."

--- a/tests/test_s3fetch.py
+++ b/tests/test_s3fetch.py
@@ -74,9 +74,9 @@ def test_filter_object_no_regex(s3fetch):
     ]
     s3fetch._regex = None
     tmp_list = []
-    for key in filter(s3fetch._filter_object, expected_objects):
+    for key in filter(s3fetch._filter_object, (obj for obj in expected_objects)):
         tmp_list.append(key)
-    assert tmp_list == expected_objects
+    assert tmp_list == expected_objects[0:-1]
 
 
 # TODO: Fixup once moto tests are working.
@@ -106,7 +106,6 @@ def test_check_for_failed_downloads(s3fetch, capfd):
     s3fetch._check_for_failed_downloads()
     out, _ = capfd.readouterr()
     assert "objects failed to download" in out
-    assert "Use --debug to see per object" in out
 
     s3fetch._debug = True
     s3fetch._check_for_failed_downloads()
@@ -152,14 +151,14 @@ def test_determine_download_dir_dir_specified_and_raises(s3fetch, mocker):
 
 def test_remove_directories(s3fetch):
     expected_objects = [
-        "one_mytestobject_one",
-        "two_mytestobject_two",
-        "three_mytestobject_three",
-        "four*mytestobject*four",
         "five)mytestobject_five",
+        "six!mytestdirectoryobject!six/",
     ]
-    s3fetch._remove_directories_from_object_listing()
-    assert s3fetch._objects == expected_objects
+    s3fetch._regex = None
+    tmp_list = []
+    for key in filter(s3fetch._filter_object, (obj for obj in expected_objects)):
+        tmp_list.append(key)
+    assert tmp_list == ["five)mytestobject_five"]
 
 
 def test_parse_and_split_s3_uri_full_path(s3fetch):


### PR DESCRIPTION
This allows us to start downloading objects as soon as we have the first object key of the first page of results.