### PR TITLE
Gracefully handle destination dir existing.

### DIFF
--- a/src/s3fetch/command.py
+++ b/src/s3fetch/command.py
@@ -245,7 +245,10 @@ class S3Fetch:
             destination_directory = self._download_dir
 
         if not destination_directory.is_dir():
-            destination_directory.mkdir(parents=True)
+            try:
+                destination_directory.mkdir(parents=True)
+            except FileExistsError:
+                pass
 
         destination_filename = destination_directory / Path(tmp_dest_filename)
 


### PR DESCRIPTION
When many threads are executing at the same time a race condition can occur where multiple threads simultaneously check if a directory exists and try to create it independently, this will cause a `FileExistsError` exception to be raised in any but the first thread to create the directory.

This PR simply catches the exception and carries on.