### PR TITLE
fix thread count discovery

### DIFF
--- a/src/s3fetch/__init__.py
+++ b/src/s3fetch/__init__.py
@@ -31,7 +31,7 @@ __version__ = pkg_resources.get_distribution("s3fetch").version
     "-t",
     "--threads",
     type=int,
-    help="Number of threads to use. Defaults to core count.",
+    help="Number of threads to use. Defaults to available core count.",
 )
 @click.option(
     "--dry-run", "--list-only", is_flag=True, help="List objects only, do not download."

--- a/src/s3fetch/command.py
+++ b/src/s3fetch/command.py
@@ -131,8 +131,8 @@ class S3Fetch:
     def _retrieve_list_of_objects(self) -> None:
         """Retrieve a list of objects in the S3 bucket under the specified path prefix."""
         if not self._quiet:
-            prefix = f"'{self._prefix}'" if self._prefix else "no prefix"
-            print(f"Listing objects in bucket '{self._bucket}' with prefix {prefix}...")
+            prefix = f"'{self._prefix}'" if self._prefix else "None"
+            print(f"Listing objects in bucket '{self._bucket}' with prefix: {prefix}")
 
         paginator = self.client.get_paginator("list_objects_v2")
         for page in paginator.paginate(Bucket=self._bucket, Prefix=self._prefix):


### PR DESCRIPTION
Closes #21 

MacOS does not support `os.sched_getaffinity()` so we use `os.cpu_count()` then instead.