### PR TITLE
Fix incorrect hatch test commands in CHANGELOG migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI Validation**: Input validation for regex patterns, thread counts, and S3 URIs
 - **Error Handling**: Improved exception handling and user-facing error messages
 - **Logging**: Better logging configuration for both CLI and library usage
-- **Documentation**: Added CLAUDE.md for development guidance
+- **Documentation**: Added AGENTS.md for development guidance
 
 ### Changed
 
@@ -225,8 +225,9 @@ poetry run nox -s tests
 ```bash
 # Hatch testing
 hatch test -a
-hatch run test_unit
-hatch run test_integration
+hatch test tests/unit
+hatch test tests/integration
+hatch test tests/e2e
 ```
 
 ### CLI Usage


### PR DESCRIPTION
## Summary

- Replaces removed `hatch run test_unit` / `hatch run test_integration` script references with the correct `hatch test tests/unit` etc. commands
- Adds the missing `hatch test tests/e2e` command
- Fixes `CLAUDE.md` reference to `AGENTS.md`

## Problem

The v1.x → v2.0 migration guide referenced hatch script entries (`hatch run test_unit`, `hatch run test_integration`) that were removed in commit `f22d158`. Anyone following the migration guide would get a `hatch: No such command` error.