### PR TITLE
Catch OSError in download_object for clear disk-full error messages

### DIFF
--- a/src/s3fetch/s3.py
+++ b/src/s3fetch/s3.py
@@ -598,6 +598,11 @@ def download_object(
         raise PermissionError(
             f"Permission error when attempting to write object to {dest_filename}"
         ) from e
+    except OSError as e:
+        tmp_filename.unlink(missing_ok=True)
+        raise OSError(
+            f"I/O error writing '{dest_filename}': {e.strerror} (errno {e.errno})"
+        ) from e
     except Exception:
         tmp_filename.unlink(missing_ok=True)
         raise


### PR DESCRIPTION
## Summary

- Adds explicit `OSError` handling in `download_object` with a clear message including `strerror` and `errno`
- Extracts `ClientError` handling into a `_raise_download_client_error` helper to keep function complexity within linter limits

## Problem

`download_object` caught `ClientError` and `PermissionError` but not `OSError`, which covers disk full (`ENOSPC`) and other I/O errors. A disk-full condition would produce an unhelpful unhandled exception in the download worker thread.

## Solution

Add an explicit `except OSError` clause that wraps the error with a clear message. The `ClientError` logic is extracted into `_raise_download_client_error` to make room without exceeding the complexity limit.