### PR TITLE
Document silent file overwrite behaviour in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
     - [Download multiple objects concurrently](#download-multiple-objects-concurrently)
     - [Filter objects using regular expressions](#filter-objects-using-regular-expressions)
   - [Troubleshooting](#troubleshooting)
+    - [Existing files are silently overwritten](#existing-files-are-silently-overwritten)
     - [MacOS hangs when downloading using high number of threads](#macos-hangs-when-downloading-using-high-number-of-threads)
 <!--toc:end-->
 
@@ -425,6 +426,15 @@ success_count, failed_downloads = download_objects(
 ```
 
 ## Troubleshooting
+
+### Existing files are silently overwritten
+
+s3fetch does not check whether a file already exists before downloading. If you run s3fetch
+twice against the same download directory, existing files will be silently overwritten with
+the latest version from S3.
+
+If you want to avoid overwriting files, use a fresh download directory or move previously
+downloaded files before re-running.
 
 ### MacOS hangs when downloading using high number of threads
 


### PR DESCRIPTION
## Summary

- Adds a Troubleshooting entry explaining that s3fetch silently overwrites existing local files
- Updates the TOC to include the new entry

## Problem

s3fetch does not check whether a file already exists before downloading — running it twice against the same directory silently overwrites all previously downloaded files. This behaviour was undocumented, which could surprise users.

## Solution

Add a clear Troubleshooting note explaining the behaviour and suggesting workarounds (fresh directory or moving files first). A `--skip-existing` flag can follow as a future feature addition.