### PR TITLE
Add tests for edge cases and fix Optional[str] type hint

### DIFF
--- a/src/s3fetch/s3.py
+++ b/src/s3fetch/s3.py
@@ -409,7 +409,7 @@ def shutdown_download_threads(executor: ThreadPoolExecutor) -> None:
     executor.shutdown(wait=False)
 
 
-def process_key(key: str, delimiter: str, prefix: str) -> Tuple[Optional[str], str]:
+def process_key(key: str, delimiter: str, prefix: str) -> Tuple[str, str]:
     """Process the object key.
 
     Rollup the object key to the nearest delimiter by the prefix and then split the
@@ -421,7 +421,7 @@ def process_key(key: str, delimiter: str, prefix: str) -> Tuple[Optional[str], s
         prefix (str): Object key prefix, .e.g. `my/test/objects/`.
 
     Returns:
-        Tuple[Optional[str], str]: Tuple containing the directory and file.
+        Tuple[str, str]: Tuple containing the directory and file.
     """
     tmp_key = rollup_object_key_by_prefix(key=key, delimiter=delimiter, prefix=prefix)
 
@@ -460,9 +460,7 @@ def rollup_object_key_by_prefix(prefix: str, delimiter: str, key: str) -> str:
     return tmp_key
 
 
-def split_object_key_into_dir_and_file(
-    key: str, delimiter: str
-) -> Tuple[Optional[str], str]:
+def split_object_key_into_dir_and_file(key: str, delimiter: str) -> Tuple[str, str]:
     """Split the object key into directory and file.
 
     Args:
@@ -471,7 +469,7 @@ def split_object_key_into_dir_and_file(
 
     Returns:
         tuple: Tuple containing the directory and file. If the delimiter is not found
-            in the object key then the directory will be None and
+            in the object key then the directory will be an empty string and
             the file will be the entire object key.
     """
     if delimiter not in key:


### PR DESCRIPTION
## Summary

- Fixes incorrect `Optional[str]` return type on `process_key` and `split_object_key_into_dir_and_file` — both return `""` not `None` for the no-directory case
- Adds unit tests for special characters and unicode in S3 object keys
- Adds unit test for 0-byte S3 objects
- Adds unit test documenting the silent overwrite behaviour

## Changes

### Type hint fix
`split_object_key_into_dir_and_file` and `process_key` were annotated as returning `Tuple[Optional[str], str]` but actually return `Tuple[str, str]` (empty string `""` for no directory). Updated annotations and docstrings to match reality.

### New tests
- `test_download_object_with_special_characters_in_key` — parametrised over spaces, URL-encoded chars, deep paths, and unicode
- `test_download_zero_byte_object` — verifies 0-byte objects produce a 0-byte local file
- `test_download_object_overwrites_existing_file` — documents that existing files are silently replaced