### PR TITLE
feat: per-object download callbacks via DownloadResult and ProgressProtocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,177 @@ The ProgressTracker provides these statistics:
 
 Note: The progress tracker is thread-safe and can be safely accessed from multiple threads.
 
+### Download Callbacks
+
+Every download attempt — success or failure — places a `DownloadResult` on the
+completed queue.  By supplying your own handler to
+`create_completed_objects_thread` you get real-time, per-object notifications
+with rich context, enabling use cases such as:
+
+- Driving a [Rich](https://rich.readthedocs.io/en/stable/progress.html) progress bar
+- Pipelining downloads directly into a compression stream (e.g. adding each
+  file to a tarball as soon as it lands, without waiting for the full download
+  to finish)
+- Ops reporting / audit logging
+
+`DownloadResult` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | `str` | S3 object key |
+| `dest_filename` | `Path` | Absolute local destination path |
+| `success` | `bool` | `True` on success, `False` on failure |
+| `file_size` | `int` | Bytes written (0 on failure or dry-run) |
+| `error` | `Exception \| None` | Exception that caused the failure, or `None` |
+
+#### Basic example — print every result
+
+```python
+import boto3
+import threading
+from s3fetch.api import create_completed_objects_thread, download_objects, list_objects
+from s3fetch.exceptions import S3FetchQueueClosed
+from s3fetch.s3 import DownloadResult, S3FetchQueue, create_download_config
+
+def my_handler(queue: S3FetchQueue) -> None:
+    while True:
+        try:
+            result: DownloadResult = queue.get(block=True)
+            status = "ok" if result.success else f"FAILED: {result.error}"
+            print(f"{result.key} ({result.file_size} bytes) — {status}")
+        except S3FetchQueueClosed:
+            break
+
+s3_client = boto3.client("s3")
+download_queue: S3FetchQueue[str] = S3FetchQueue()
+completed_queue: S3FetchQueue[DownloadResult] = S3FetchQueue()
+exit_event = threading.Event()
+
+list_objects(
+    bucket="my-bucket",
+    prefix="exports/2024/",
+    client=s3_client,
+    download_queue=download_queue,
+    delimiter="/",
+    regex=None,
+    exit_event=exit_event,
+)
+
+# Start your custom handler *before* downloading
+create_completed_objects_thread(queue=completed_queue, func=my_handler)
+
+download_config = create_download_config()
+success_count, failed_downloads = download_objects(
+    client=s3_client,
+    threads=10,
+    download_queue=download_queue,
+    completed_queue=completed_queue,
+    exit_event=exit_event,
+    bucket="my-bucket",
+    prefix="exports/2024/",
+    download_dir="./downloads",
+    delimiter="/",
+    download_config=download_config,
+)
+```
+
+#### Pipeline example — compress as files arrive
+
+This pattern lets you add each downloaded file to a tar archive concurrently
+with ongoing downloads, rather than waiting for all downloads to finish first:
+
+```python
+import queue
+import tarfile
+import threading
+from pathlib import Path
+
+import boto3
+from s3fetch.api import create_completed_objects_thread, download_objects, list_objects
+from s3fetch.exceptions import S3FetchQueueClosed
+from s3fetch.s3 import DownloadResult, S3FetchQueue, create_download_config
+
+# A small work queue between the download handler and the tar thread
+tar_queue: queue.Queue = queue.Queue()
+
+def on_download(queue: S3FetchQueue) -> None:
+    """Forward successful downloads to the tar work queue."""
+    while True:
+        try:
+            result: DownloadResult = queue.get(block=True)
+            if result.success:
+                tar_queue.put(result.dest_filename)
+        except S3FetchQueueClosed:
+            tar_queue.put(None)  # sentinel
+            break
+
+def tar_worker(archive_path: Path) -> None:
+    """Compress files as they arrive from the download handler."""
+    with tarfile.open(archive_path, "w:gz") as tar:
+        while True:
+            path = tar_queue.get()
+            if path is None:
+                break
+            tar.add(path, arcname=path.name)
+            print(f"Compressed {path.name}")
+
+# Start the compression thread
+archive = Path("output.tar.gz")
+threading.Thread(target=tar_worker, args=(archive,), daemon=True).start()
+
+# Run the download
+s3_client = boto3.client("s3")
+download_queue: S3FetchQueue[str] = S3FetchQueue()
+completed_queue: S3FetchQueue[DownloadResult] = S3FetchQueue()
+exit_event = threading.Event()
+
+list_objects(
+    bucket="my-bucket",
+    prefix="data/",
+    client=s3_client,
+    download_queue=download_queue,
+    delimiter="/",
+    regex=None,
+    exit_event=exit_event,
+)
+
+create_completed_objects_thread(queue=completed_queue, func=on_download)
+
+download_config = create_download_config()
+download_objects(
+    client=s3_client,
+    threads=20,
+    download_queue=download_queue,
+    completed_queue=completed_queue,
+    exit_event=exit_event,
+    bucket="my-bucket",
+    prefix="data/",
+    download_dir="./downloads",
+    delimiter="/",
+    download_config=download_config,
+)
+```
+
+#### Custom progress tracker
+
+You can also implement the `ProgressProtocol` to receive aggregate counts
+during listing and downloading without needing the completed queue at all:
+
+```python
+from s3fetch import ProgressProtocol
+
+class MyTracker:
+    """Minimal tracker that satisfies ProgressProtocol."""
+
+    def increment_found(self) -> None:
+        print(".", end="", flush=True)  # one dot per object listed
+
+    def increment_downloaded(self, bytes_count: int) -> None:
+        print(f" +{bytes_count // 1024}KB", end="", flush=True)
+
+# Pass to list_objects and download_objects via progress_tracker=MyTracker()
+```
+
 ### Advanced Usage
 
 ```python

--- a/src/s3fetch/__init__.py
+++ b/src/s3fetch/__init__.py
@@ -1,5 +1,13 @@
 import logging
 
+from .s3 import DownloadResult
+from .utils import ProgressProtocol
+
 logger = logging.getLogger("s3fetch")
 
 __version__ = "2.0.0"
+
+__all__ = [
+    "DownloadResult",
+    "ProgressProtocol",
+]

--- a/src/s3fetch/api.py
+++ b/src/s3fetch/api.py
@@ -8,7 +8,8 @@ from typing import Any, Callable, Dict, Optional, Tuple, Union
 from mypy_boto3_s3.client import S3Client
 
 from . import s3
-from .s3 import S3FetchQueue
+from .s3 import DownloadResult, S3FetchQueue
+from .utils import ProgressProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -17,11 +18,11 @@ def list_objects(
     bucket: str,
     prefix: str,
     client: S3Client,
-    download_queue: S3FetchQueue,
+    download_queue: "S3FetchQueue[str]",
     delimiter: str,
     regex: Optional[str],
     exit_event: threading.Event,
-    progress_tracker: Optional[Any] = None,  # noqa: ANN401
+    progress_tracker: Optional[ProgressProtocol] = None,
 ) -> None:
     """Starts a seperate thread that lists of objects from the specified S3 bucket.
 
@@ -33,11 +34,11 @@ def list_objects(
         bucket (str): S3 bucket name.
         prefix (str): S3 object key prefix.
         client (S3Client): Boto3 S3 client object.
-        download_queue (S3FetchQueue): FIFO download queue.
+        download_queue (S3FetchQueue[str]): FIFO download queue.
         delimiter (str): Delimiter for the logical folder hierarchy.
         regex (Optional[str]): Regular expression to use for filtering objects.
         exit_event (threading.Event): Notify that script to exit.
-        progress_tracker (Optional[Any]): Progress tracker instance.
+        progress_tracker (Optional[ProgressProtocol]): Progress tracker instance.
     """
     list_objects_thread = s3.create_list_objects_thread(
         bucket=bucket,
@@ -55,8 +56,8 @@ def list_objects(
 def download_objects(
     client: S3Client,
     threads: int,
-    download_queue: S3FetchQueue,
-    completed_queue: S3FetchQueue,
+    download_queue: "S3FetchQueue[str]",
+    completed_queue: "S3FetchQueue[DownloadResult]",
     exit_event: threading.Event,
     bucket: str,
     prefix: str,
@@ -64,15 +65,19 @@ def download_objects(
     delimiter: str,
     download_config: dict,
     dry_run: bool = False,
-    progress_tracker: Optional[Any] = None,  # noqa: ANN401
+    progress_tracker: Optional[ProgressProtocol] = None,
 ) -> Tuple[int, list]:
     """Download objects from S3 bucket.
 
     Args:
         client (S3Client): S3 client, e.g. boto3.client("s3").
         threads (int): Number of threads to use.
-        download_queue (S3FetchQueue): Download queue.
-        completed_queue (S3FetchQueue): Completed download queue.
+        download_queue (S3FetchQueue[str]): Download queue.
+        completed_queue (S3FetchQueue[DownloadResult]): Completed download queue.
+            A :class:`~s3fetch.s3.DownloadResult` is placed on this queue for
+            every download attempt, regardless of success or failure.  Pass your
+            own consumer thread via :func:`create_completed_objects_thread` to
+            react to each result in real time.
         exit_event (threading.Event): Notify that script to exit.
         bucket (str): S3 bucket name, e.g. my-bucket.
         prefix (str): S3 object key prefix, e.g. my-folder/.
@@ -80,10 +85,11 @@ def download_objects(
         delimiter (str): S3 object key delimiter.
         download_config (dict): Download configuration.
         dry_run (bool): Run in dry run mode.
-        progress_tracker (Optional[Any]): Progress tracker instance.
+        progress_tracker (Optional[ProgressProtocol]): Progress tracker instance.
 
     Returns:
-        Tuple[int, list]: Number of successful downloads and list of failed downloads.
+        Tuple[int, list]: Number of successful downloads and list of failed
+            downloads as ``(key, exception)`` tuples.
     """
     # Convert string to Path if needed
     if isinstance(download_dir, str):
@@ -109,17 +115,32 @@ def download_objects(
 
 
 def create_completed_objects_thread(
-    queue: S3FetchQueue,
+    queue: "S3FetchQueue[DownloadResult]",
     func: Callable[..., None],
     **kwargs: Dict[str, Any],
 ) -> None:
-    """Create a thread to monitor for completed objects.
+    """Create a thread to consume completed download results.
+
+    The ``func`` is called in a new daemon thread with the ``queue`` as its
+    first keyword argument, plus any additional ``kwargs``.  It should loop
+    calling ``queue.get(block=True)`` until
+    :class:`~s3fetch.exceptions.S3FetchQueueClosed` is raised.
+
+    Each item yielded by the queue is a :class:`~s3fetch.s3.DownloadResult`
+    containing the key, destination path, success flag, file size, and any
+    error that occurred.  This gives consumers real-time, per-object
+    notification for both successes and failures.
+
+    The built-in :func:`~s3fetch.utils.print_completed_objects` function can
+    be used here for simple CLI-style output, or you can supply your own
+    handler for custom behaviour such as Rich progress bars or pipelining
+    downloads into a compression stream.
 
     Args:
-        queue (S3FetchQueue): FIFO download queue.
-        func (Callable[..., None]): Function to run in a new thread. Will receive the
-            completed objects queue and any additional kwargs passed.
-        **kwargs: Any additional arguments to pass to `func`.
+        queue (S3FetchQueue[DownloadResult]): Completed-downloads queue.
+        func (Callable[..., None]): Function to run in a new thread. Will receive
+            the completed objects queue and any additional kwargs passed.
+        **kwargs: Any additional arguments to pass to ``func``.
     """
     logger.debug("Creating completed objects thread")
     threading.Thread(

--- a/tests/integration/test_download_reporting.py
+++ b/tests/integration/test_download_reporting.py
@@ -8,6 +8,7 @@ from moto import mock_aws
 
 from s3fetch import api, s3
 from s3fetch.exceptions import S3FetchQueueClosed
+from s3fetch.s3 import DownloadResult
 
 
 @mock_aws
@@ -67,7 +68,7 @@ def test_download_success_and_failure_reporting(tmpdir):
     # Check that the failed key matches our non-existent key
     assert failures[0][0] == non_existent_key
 
-    # Verify completed queue has the correct items
+    # Verify completed queue has the correct items (now DownloadResult objects)
     completed_items = []
     try:
         while True:
@@ -75,9 +76,13 @@ def test_download_success_and_failure_reporting(tmpdir):
     except S3FetchQueueClosed:
         pass
 
-    assert len(completed_items) == 2, "Completed queue should have 2 items"
-    # Check that completed items match the valid keys
-    assert set(completed_items) == set(valid_keys)
+    # All items on the queue are DownloadResult objects
+    assert all(isinstance(item, DownloadResult) for item in completed_items)
+    # Only successful downloads should appear with success=True
+    successful_items = [item for item in completed_items if item.success]
+    assert len(successful_items) == 2, "Completed queue should have 2 successful items"
+    # Check that successful keys match the valid keys
+    assert {item.key for item in successful_items} == set(valid_keys)
 
     # Verify files were actually downloaded
     for key in valid_keys:
@@ -86,3 +91,122 @@ def test_download_success_and_failure_reporting(tmpdir):
         file_path = download_dir / dir_name / file_name
         assert file_path.exists(), f"Downloaded file {file_path} should exist"
         assert file_path.read_text() == f"Content of {key}", "File content should match"
+
+
+@mock_aws
+def test_failed_download_emits_download_result_with_success_false(tmpdir):
+    """Failed downloads emit a DownloadResult(success=False) on the completed queue."""
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    bucket_name = "test-bucket"
+    s3_client.create_bucket(Bucket=bucket_name)
+
+    download_queue = s3.get_queue("download")
+    completed_queue = s3.get_queue("completion")
+    exit_event = threading.Event()
+
+    # Only enqueue a key that does not exist in S3
+    non_existent_key = "does/not/exist.txt"
+    download_queue.put(non_existent_key)
+    download_queue.close()
+
+    download_dir = Path(tmpdir)
+    download_config = s3.create_download_config()
+
+    success_count, failures = api.download_objects(
+        client=s3_client,
+        threads=1,
+        download_queue=download_queue,
+        completed_queue=completed_queue,
+        exit_event=exit_event,
+        bucket=bucket_name,
+        prefix="",
+        download_dir=download_dir,
+        delimiter="/",
+        download_config=download_config,
+        dry_run=False,
+    )
+
+    assert success_count == 0
+    assert len(failures) == 1
+
+    # The failure should still emit a DownloadResult on the completed queue
+    completed_items = []
+    try:
+        while True:
+            completed_items.append(completed_queue.get())
+    except S3FetchQueueClosed:
+        pass
+
+    assert len(completed_items) == 1
+    result = completed_items[0]
+    assert isinstance(result, DownloadResult)
+    assert result.key == non_existent_key
+    assert result.success is False
+    assert result.error is not None
+    assert result.file_size == 0
+
+
+@mock_aws
+def test_create_completed_objects_thread_with_custom_handler(tmpdir):
+    """create_completed_objects_thread works with a custom DownloadResult handler."""
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    bucket_name = "test-bucket"
+    s3_client.create_bucket(Bucket=bucket_name)
+
+    test_objects = {"file1.txt": "aaa", "file2.txt": "bb"}
+    for key, body in test_objects.items():
+        s3_client.put_object(Bucket=bucket_name, Key=key, Body=body)
+
+    download_queue = s3.get_queue("download")
+    completed_queue: s3.S3FetchQueue[DownloadResult] = s3.S3FetchQueue()
+    exit_event = threading.Event()
+
+    for key in test_objects:
+        download_queue.put(key)
+    download_queue.close()
+
+    # Custom handler that collects results
+    collected: list[DownloadResult] = []
+
+    def my_handler(queue: s3.S3FetchQueue[DownloadResult]) -> None:
+        from s3fetch.exceptions import S3FetchQueueClosed as Closed
+
+        while True:
+            try:
+                collected.append(queue.get(block=True))
+            except Closed:
+                break
+
+    api.create_completed_objects_thread(queue=completed_queue, func=my_handler)
+
+    download_dir = Path(tmpdir)
+    download_config = s3.create_download_config()
+
+    success_count, failures = api.download_objects(
+        client=s3_client,
+        threads=2,
+        download_queue=download_queue,
+        completed_queue=completed_queue,
+        exit_event=exit_event,
+        bucket=bucket_name,
+        prefix="",
+        download_dir=download_dir,
+        delimiter="/",
+        download_config=download_config,
+    )
+
+    # Give the handler thread a moment to finish draining
+    import time
+
+    time.sleep(0.1)
+
+    assert success_count == 2
+    assert len(failures) == 0
+    assert len(collected) == 2
+    assert all(isinstance(r, DownloadResult) for r in collected)
+    assert all(r.success for r in collected)
+    assert {r.key for r in collected} == set(test_objects)
+    # file_size should reflect actual content sizes
+    for r in collected:
+        expected_size = len(test_objects[r.key].encode())
+        assert r.file_size == expected_size

--- a/tests/integration/test_dry_run.py
+++ b/tests/integration/test_dry_run.py
@@ -8,7 +8,7 @@ from moto import mock_aws
 
 from s3fetch.api import download_objects, list_objects
 from s3fetch.exceptions import S3FetchQueueClosed
-from s3fetch.s3 import S3FetchQueue, create_download_config
+from s3fetch.s3 import DownloadResult, S3FetchQueue, create_download_config
 
 
 @mock_aws
@@ -81,8 +81,9 @@ def test_dry_run_functionality(tmpdir):
 
     # Verify all items were reported as completed
     assert len(completed_items) == len(test_objects), "All items should be counted"
-    # Check that completed queue has all test objects
-    assert set(completed_items) == set(test_objects)
+    # Each item is now a DownloadResult; extract the keys for comparison
+    assert all(isinstance(item, DownloadResult) for item in completed_items)
+    assert {item.key for item in completed_items} == set(test_objects)
 
     # Most importantly, verify no files were actually downloaded
     downloaded_files = list(download_dir.rglob("*.*"))  # Get all files, not directories

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,6 +2,43 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 
 from s3fetch import utils
+from s3fetch.utils import ProgressProtocol, ProgressTracker
+
+
+class TestProgressProtocol:
+    """Tests for the ProgressProtocol structural interface."""
+
+    def test_progress_tracker_satisfies_protocol(self):
+        """ProgressTracker must satisfy ProgressProtocol (runtime_checkable)."""
+        tracker = ProgressTracker()
+        assert isinstance(tracker, ProgressProtocol)
+
+    def test_custom_class_satisfies_protocol(self):
+        """Any class with the two required methods satisfies ProgressProtocol."""
+
+        class MinimalTracker:
+            def increment_found(self) -> None:
+                pass
+
+            def increment_downloaded(self, bytes_count: int) -> None:
+                pass
+
+        assert isinstance(MinimalTracker(), ProgressProtocol)
+
+    def test_missing_method_fails_protocol_check(self):
+        """A class missing either method should not satisfy ProgressProtocol."""
+
+        class IncompleteTracker:
+            def increment_found(self) -> None:
+                pass
+
+            # increment_downloaded is absent
+
+        assert not isinstance(IncompleteTracker(), ProgressProtocol)
+
+    def test_none_does_not_satisfy_protocol(self):
+        """None should not satisfy ProgressProtocol."""
+        assert not isinstance(None, ProgressProtocol)
 
 
 def test_create_exit_event():


### PR DESCRIPTION
Closes #26

## Summary

This implements the feature requested in #26 — real-time, per-object callback notifications during downloads — using the existing queue infrastructure rather than adding a new callback parameter thread.

## What changed

### New: `DownloadResult` dataclass (`s3fetch.s3`)

After every download attempt (success **or** failure) a `DownloadResult` is placed on the completed queue:

```python
@dataclass
class DownloadResult:
    key: str                        # S3 object key
    dest_filename: Path             # absolute local destination
    success: bool                   # True on success
    file_size: int = 0              # bytes written (0 on failure/dry-run)
    error: Optional[Exception] = None  # exception on failure, else None
```

### New: `ProgressProtocol` (`s3fetch.utils`)

A `typing.Protocol` (structural, `runtime_checkable`) that replaces `Optional[Any]` across `s3.py`, `api.py`, and `cli.py`. Any object implementing `increment_found()` and `increment_downloaded(bytes_count)` satisfies it — no inheritance needed. `ProgressTracker` already conforms with no changes.

### Generic `S3FetchQueue[T]`

`S3FetchQueue` is now generic so the two queue instances are typed correctly:
- Download queue: `S3FetchQueue[str]`
- Completed queue: `S3FetchQueue[DownloadResult]`

### Failure notification (real-time)

Previously, failed downloads were only reported in the aggregated `(success_count, failures)` tuple returned after all downloads finished. Now a `DownloadResult(success=False, error=<exception>)` is also pushed onto the completed queue immediately, so consumers can react to failures in real time.

### `print_completed_objects` updated (backward compatible)

The CLI's built-in consumer now reads `DownloadResult` objects and prints `result.key` for successful downloads. Output is unchanged from the user's perspective.

### Public exports

`DownloadResult` and `ProgressProtocol` are now exported from the top-level `s3fetch` package.

## Usage

```python
from s3fetch.api import create_completed_objects_thread, download_objects, list_objects
from s3fetch.exceptions import S3FetchQueueClosed
from s3fetch.s3 import DownloadResult, S3FetchQueue, create_download_config

def my_handler(queue: S3FetchQueue) -> None:
    while True:
        try:
            result: DownloadResult = queue.get(block=True)
            status = "ok" if result.success else f"FAILED: {result.error}"
            print(f"{result.key} ({result.file_size} bytes) — {status}")
        except S3FetchQueueClosed:
            break

completed_queue: S3FetchQueue[DownloadResult] = S3FetchQueue()
create_completed_objects_thread(queue=completed_queue, func=my_handler)
# ... then call download_objects() as normal
```

See the new **Download Callbacks** section in the README for a full pipeline example (downloading directly into a tar archive as files arrive).

## Tests

10 new tests added (145 → 155):
- `DownloadResult` pushed on success with correct `file_size`
- `DownloadResult` pushed on failure with `success=False` and `error` set
- `DownloadResult` in dry-run has `file_size=0`
- Generic queue typing works correctly
- `ProgressTracker` satisfies `ProgressProtocol` (runtime check)
- Custom class satisfying / not satisfying the protocol
- Integration: failed downloads emit real-time result on completed queue
- Integration: custom handler pattern end-to-end