### PR TITLE
chore: add Python 3.14 to testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Utilities",
 ]
 dependencies = ["boto3==1.40.38", "boto3-stubs[s3]==1.40.38", "click==8.3.0"]
@@ -48,7 +49,7 @@ extra-dependencies = [
 ]
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.13", "3.12", "3.11", "3.10"]
+python = ["3.14", "3.13", "3.12", "3.11", "3.10"]
 
 [project.urls]
 Source = "https://github.com/rxvt/s3fetch"


### PR DESCRIPTION
## Summary

- Adds Python 3.14 to the CI test matrix in `.github/workflows/test.yml`
- Adds Python 3.14 classifier to `pyproject.toml`
- No EOL versions to remove — all current versions (3.10–3.13) remain actively supported upstream

## Python version status (as of Feb 2026)

| Version | Status | EOL |
|---------|--------|-----|
| 3.10 | security | Oct 2026 |
| 3.11 | security | Oct 2027 |
| 3.12 | bugfix | Oct 2028 |
| 3.13 | bugfix | Oct 2029 |
| 3.14 | bugfix | Oct 2030 |

Closes #50